### PR TITLE
Typo in favicon path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
 	<link rel="shortcut icon" href="./images/favicon/favicon.ico">
 	<link rel="apple-touch-icon" sizes="180x180" href="./images/favicon/apple-touch-icon.png">
 	<link rel="icon" type="image/png" sizes="32x32" href="./images/favicon/favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="./image/favicon/favicon-16x16.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="./images/favicon/favicon-16x16.png">
 	<link rel="mask-icon" href="./images/favicon/safari-pinned-tab.svg" color="#0e2437">
 
 	<link rel="stylesheet" href="./style/colors.css">


### PR DESCRIPTION
The path for the 16x16 favicon image was wrong.
It was `image/favicon/favicon-16x16.png` instead of `images/favicon/favicon-16x16.png` (look at the `s` of `images/`)