### PR TITLE
Update the context menu prio when it changes while it's open

### DIFF
--- a/src/components/TorrentList/TorrentList.svelte
+++ b/src/components/TorrentList/TorrentList.svelte
@@ -37,6 +37,8 @@
       }
     }
   }
+  // If the prio changes while the contextMenu is open, update the prio in the context menu
+  $: contextMenu.updateProps({ prio });
 
   const handleTorrentClick = ({
     detail: { torrent, modifierKey },

--- a/src/helpers/stores/contextMenu.js
+++ b/src/helpers/stores/contextMenu.js
@@ -7,6 +7,17 @@ function createContextMenuStore() {
     subscribe,
     set,
     update,
+    updateProps: (partialProps) =>
+      update(($contextMenu) => {
+        if (!$contextMenu) return $contextMenu;
+        return {
+          ...$contextMenu,
+          props: {
+            ...$contextMenu.props,
+            ...partialProps,
+          },
+        };
+      }),
     open: ({
       component,
       props = {},


### PR DESCRIPTION
This will ensure that the contextMenu priority will always represent the proper priority value. It will update the priority while the context menu is open.

This should resolve: https://github.com/johman10/flood-for-transmission/issues/230