### PR TITLE
Support copy magnet link in unsecure context

### DIFF
--- a/src/helpers/copyHelper.js
+++ b/src/helpers/copyHelper.js
@@ -1,0 +1,20 @@
+export function copyToClipboard(textToCopy) {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(textToCopy);
+  }
+
+  return new Promise((resolve, reject) => {
+    let textArea = document.createElement('textarea');
+    textArea.value = textToCopy;
+
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-999999px';
+    textArea.style.top = '-999999px';
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    document.execCommand('copy') ? resolve() : reject();
+    textArea.remove();
+  });
+}

--- a/src/helpers/stores/torrents.js
+++ b/src/helpers/stores/torrents.js
@@ -33,6 +33,7 @@ import {
   labelFilter,
 } from '~helpers/filterHelper';
 import { trackerStripper } from '~helpers/trackerHelper';
+import { copyToClipboard } from '../copyHelper';
 
 const TORRENT_FETCHING_TIMEOUT = 1000;
 
@@ -295,8 +296,8 @@ function createTorrentsStore() {
       const magnetLinks = selectedTorrents.map(
         (torrent) => torrent[TRANSMISSION_COLUMN_MAGNET_LINK]
       );
-      return navigator.clipboard
-        .writeText(magnetLinks.join(', '))
+
+      return copyToClipboard(magnetLinks.join(', '))
         .then(() => {
           alerts.add('Magnet links copied');
         })


### PR DESCRIPTION
This allows users to copy magnet link when they don't have https configured.

Note: the fallback API is deprecated and so might not be a long term solution, but I can support it until browsers really drop support, after that I'm afraid I might have to hide the copy magnet link or throw a nicer error message when used without https.

Resolves: https://github.com/johman10/flood-for-transmission/issues/386