### PR TITLE
Add support for table header wrapping

### DIFF
--- a/src/components/Checkbox/Checkbox.svelte
+++ b/src/components/Checkbox/Checkbox.svelte
@@ -15,7 +15,7 @@
   const id = `input-checkbox-${num}`;
 </script>
 
-<label for="{id}" tabindex="0" class="checkbox label">
+<label for="{id}" tabindex="0" class="checkbox">
   {#if group && value}
     <input type="checkbox" bind:group value="{value}" id="{id}" on:change />
     <div class="indicator" class:checked="{group.includes(value)}">
@@ -69,21 +69,21 @@
     margin-left: 6px;
   }
 
-  .label:active .indicator > :global(.icon) {
+  .checkbox:active .indicator > :global(.icon) {
     opacity: 0.25;
   }
 
-  .label .indicator.checked > :global(.icon) {
+  .checkbox .indicator.checked > :global(.icon) {
     opacity: 1;
   }
 
-  .label:focus,
-  .label:active {
+  .checkbox:focus,
+  .checkbox:active {
     color: var(--color-checkbox-text-active);
   }
 
-  .label:active .indicator,
-  .label:focus .indicator {
+  .checkbox:active .indicator,
+  .checkbox:focus .indicator {
     background-color: var(--color-checkbox-background-active);
     border-color: var(--color-checkbox-border-active);
     fill: var(--color-checkbox-mark-active);

--- a/src/components/Modal/Settings/UserInterface.svelte
+++ b/src/components/Modal/Settings/UserInterface.svelte
@@ -12,6 +12,7 @@
     darkMode,
     switchSpeedColors,
     timeConfig,
+    tableHeaderConfig,
   } from '~helpers/stores';
   import { orderable } from '~helpers/actions';
 
@@ -19,6 +20,7 @@
   let newPaths = [...$paths];
   let newSwitchSpeedColors = $switchSpeedColors;
   let newTimeConfig = $timeConfig;
+  let newTableHeaderConfig = $tableHeaderConfig;
   const configuredDarkMode = darkMode.configuredValue;
   let newDarkMode = $configuredDarkMode;
 
@@ -34,6 +36,7 @@
       paths.set(newPaths);
       switchSpeedColors.set(newSwitchSpeedColors);
       timeConfig.set(newTimeConfig);
+      tableHeaderConfig.set(newTableHeaderConfig);
       darkMode.set(newDarkMode);
       alerts.add('Succesfully saved user interface settings');
     } catch (e) {
@@ -70,11 +73,20 @@
     />
   </div>
 
+  <Header text="Format" />
   <div class="list">
     <Checkbox
       label="24-hour notation"
       hint="Will represent time with 24 hours if enabled and 12 hours if disabled"
       bind:checked="{newTimeConfig}"
+    />
+  </div>
+
+  <div class="list">
+    <Checkbox
+      label="Wrap overflowing text in table headers"
+      hint="Will wrap text in header columns when enabled"
+      bind:checked="{newTableHeaderConfig}"
     />
   </div>
 
@@ -118,10 +130,6 @@
     flex-direction: column;
     line-height: 1;
     color: var(--color-modal-text);
-  }
-
-  form :global(.checkbox) {
-    font-size: 11px;
   }
 
   form :global(.checkbox) :global(.indicator) {

--- a/src/components/TorrentList/ColumnHeader.svelte
+++ b/src/components/TorrentList/ColumnHeader.svelte
@@ -1,6 +1,6 @@
 <script>
   import { resizeableTable } from '~helpers/actions';
-  import { uiColumns, sorting } from '~helpers/stores';
+  import { uiColumns, sorting, tableHeaderConfig } from '~helpers/stores';
 
   export let id;
 
@@ -25,6 +25,7 @@
     class:sorting="{id === $sorting.id}"
     class:asc="{$sorting.id === id && $sorting.direction === 'asc'}"
     class:desc="{$sorting.id === id && $sorting.direction === 'desc'}"
+    class:wrap="{$tableHeaderConfig}"
     style="width: {$columnSizes[id]}px"
     on:click="{handleClick}"
   >
@@ -60,6 +61,10 @@
     color: var(--color-column-header-text-active);
     font-weight: 700;
     padding: 0 16px 0 8px;
+  }
+
+  .header.wrap {
+    white-space: normal;
   }
 
   .header:after {

--- a/src/helpers/stores/index.js
+++ b/src/helpers/stores/index.js
@@ -13,6 +13,7 @@ export { session } from './session';
 export { sessionStats } from './sessionStats';
 export { sorting } from './sorting';
 export { switchSpeedColors } from './switchSpeedColors';
+export { tableHeaderConfig } from './tableHeaderConfig';
 export { timeConfig } from './timeConfig';
 export { torrentDetails } from './torrentDetails';
 export { torrents } from './torrents';

--- a/src/helpers/stores/tableHeaderConfig.js
+++ b/src/helpers/stores/tableHeaderConfig.js
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+const LOCAL_STORAGE_KEY = 'tableHeaderConfig';
+
+function getConfiguredValue() {
+  const storedConfig = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (storedConfig === null) {
+    return false;
+  }
+  return storedConfig === 'true';
+}
+
+function createTableHeaderConfig() {
+  const { subscribe, set, update } = writable(getConfiguredValue());
+
+  return {
+    subscribe,
+    set: (value) => {
+      window.localStorage.setItem(LOCAL_STORAGE_KEY, value);
+      set(value);
+    },
+    update,
+  };
+}
+
+export const tableHeaderConfig = createTableHeaderConfig();


### PR DESCRIPTION
This adds a config to enable or disable wrapping the column headers when overflow is happening. It should implement the behaviour as described in the linked issue.

If the column is so small that a word doesn't fit it will still use ellipsis to indicate the hidden part of the text.
The default behaviour hasn't changed.

Resolves: #406 