### PR TITLE
Fixed ETA sorting for other negative values

### DIFF
--- a/src/helpers/stores/torrents.js
+++ b/src/helpers/stores/torrents.js
@@ -73,10 +73,11 @@ const sorted = derived(
             bValue = bValue.toLowerCase();
           }
 
-          // Transmission ETA -1, is infinity so mimic that behaviour
+          // Transmission ETA less than 0 is unknown/infinity so mimic that behaviour.
+          // Reference: https://github.com/transmission/transmission/blob/3.00/libtransmission/transmission.h#L1748-L1749
           if (transmissionColumn === TRANSMISSION_COLUMN_ETA) {
-            if (aValue === -1) aValue = Number.MAX_SAFE_INTEGER;
-            if (bValue === -1) bValue = Number.MAX_SAFE_INTEGER;
+            if (aValue < 0) aValue = Number.MAX_SAFE_INTEGER;
+            if (bValue < 0) bValue = Number.MAX_SAFE_INTEGER;
           }
 
           // TODO: consider some way of setting a sorting value/key per column so that this can be abstracted


### PR DESCRIPTION
I've noticed that the sorting was broken due to -2 values returned by Transmission. Negative values are never valid for eta so I updated the relevant section to treat them all as infinity.

Related code: https://github.com/transmission/transmission/blob/9e07b6f4c570a84b8ff5ef97ee41dfbce0b30726/libtransmission/transmission.h#L1637-L1638

See #222 for the original issue, #254 for the original fix.