### PR TITLE
Fix normal priority filter

### DIFF
--- a/src/helpers/stores/torrents.js
+++ b/src/helpers/stores/torrents.js
@@ -47,7 +47,7 @@ const sorted = derived(
   [store, filters, sorting],
   ([$torrents, $filters, $sorting]) => {
     let filteredTorrents = $torrents;
-    const hasFilter = !!Object.values($filters).filter((value) => value !== null).length
+    const hasFilter = !!Object.values($filters).filter((value) => value !== null).length;
     if (hasFilter) {
       filteredTorrents = $torrents.filter((torrent) => {
         const search = searchFilter($filters.search, torrent);

--- a/src/helpers/stores/torrents.js
+++ b/src/helpers/stores/torrents.js
@@ -47,7 +47,7 @@ const sorted = derived(
   [store, filters, sorting],
   ([$torrents, $filters, $sorting]) => {
     let filteredTorrents = $torrents;
-    const hasFilter = !!Object.values($filters).filter(Boolean).length || $filters.priority !== null;
+    const hasFilter = !!Object.values($filters).filter((value) => value !== null).length
     if (hasFilter) {
       filteredTorrents = $torrents.filter((torrent) => {
         const search = searchFilter($filters.search, torrent);

--- a/src/helpers/stores/torrents.js
+++ b/src/helpers/stores/torrents.js
@@ -47,7 +47,7 @@ const sorted = derived(
   [store, filters, sorting],
   ([$torrents, $filters, $sorting]) => {
     let filteredTorrents = $torrents;
-    const hasFilter = !!Object.values($filters).filter(Boolean).length;
+    const hasFilter = !!Object.values($filters).filter(Boolean).length || $filters.priority !== null;
     if (hasFilter) {
       filteredTorrents = $torrents.filter((torrent) => {
         const search = searchFilter($filters.search, torrent);


### PR DESCRIPTION
if there is only a priority filter with value normal (0), `hasFilter` becomes false and normal priority filter does not work (as if there is no filter applied at all).