### PR TITLE
Trim new tracker url

### DIFF
--- a/src/components/Modal/TorrentDetail/Trackers/Trackers.svelte
+++ b/src/components/Modal/TorrentDetail/Trackers/Trackers.svelte
@@ -30,7 +30,7 @@
 
   const addTracker = (event) => {
     event.preventDefault();
-    torrentDetails.addTrackers($torrentDetails, [newTracker]);
+    torrentDetails.addTrackers($torrentDetails, [newTracker.trim()]);
     newTracker = null;
   };
 </script>


### PR DESCRIPTION
OpenBitTorrent appends a space to the tracker url when you copy it from the website. Transmission returns an error when new tracker url has leading or trailing spaces.

I almost filed an issue about being unable to add UDP trackers, haha