### PR TITLE
Lower priority by right-clicking

### DIFF
--- a/src/components/PriorityIndicator/PriorityIndicator.svelte
+++ b/src/components/PriorityIndicator/PriorityIndicator.svelte
@@ -44,11 +44,22 @@
     }
     dispatch('click', newPriority);
   };
+
+  const handleRightClick = () => {
+    let newPriority = value - 1;
+    if (newPriority < -1 && !allowDisabled) {
+      newPriority = 1;
+    } else if (newPriority < -2) {
+      newPriority = 1;
+    }
+    dispatch('click', newPriority);
+  };
 </script>
 
 <div
   class="priority-indicator"
   on:click="{handleClick}"
+  on:contextmenu|preventDefault="{handleRightClick}"
   bind:this="{element}"
   title="{showLabel ? undefined : label}"
 >


### PR DESCRIPTION
Currently, to lower the priority of a torrent or file, you have to click a few times. I suggest that clicking with the right mouse button lowers the priority.

This minimal change allows that functionality.