### PR TITLE
Fix column reordering in Safari and Firefox

### DIFF
--- a/src/helpers/actions/orderable.js
+++ b/src/helpers/actions/orderable.js
@@ -1,16 +1,21 @@
 let draggingElement;
 
+const emptyImage = document.createElement("img");   
+emptyImage.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+
 export default function orderable(item, handleDrop) {
   const list = item.parentNode;
 
   const onDragStart = (e) => {
-    e.dataTransfer.setDragImage(document.createElement('div'), 0, 0);
+    e.dataTransfer.setDragImage(emptyImage, 0, 0);
     draggingElement = item;
     draggingElement.style = 'opacity: .6';
   };
 
   const onDragOver = (event) => {
     event.preventDefault();
+
+    if (draggingElement.id === item.id) return;
 
     if (event.offsetY < 2) {
       list.insertBefore(draggingElement, item.nextSibling);


### PR DESCRIPTION
Fixes #427 

Noticed this problem in Firefox as well. I think this pull request addresses 2 little problems:

1. The `dragover` event gets fired continuously during dragging. On the callback the DOM is manipulated to update the list. Somehow Chrome handles this pretty well but on Firefox it just flooded the event queue I guess and the `drop` event was not fired most of the time. I added a simple check below to see if we should update the DOM or not. 

```javascript
if (draggingElement.id === item.id) return;
```

2. Now Firefox was working, but Safari was still giving problems. Setting the drag image to an empty div doesn't work in Safari [apparently](https://stackoverflow.com/a/40923520/943337). I replaced it with an inline GIF, a 1x1 transparent pixel, [the smallest I could find](https://stackoverflow.com/a/9967193/943337).

Tested on Firefox, Safari and Chrome. Thanks for your work!