### PR TITLE
Clear token upon error

### DIFF
--- a/src/helpers/Transmission.js
+++ b/src/helpers/Transmission.js
@@ -65,6 +65,7 @@ export default class Transmission {
         headers,
       });
       if (!response.ok) {
+        this._tokenHeader = null;
         throw new Error(response.statusText);
       }
       const output = await response.json();


### PR DESCRIPTION
This will clear the token whenever there is an error. This should prevent a loop where errors authentication errors keep on happening without prompting for Basic Auth information.