### PR TITLE
Allow to bulk add multiple items

### DIFF
--- a/src/components/Input/Input.svelte
+++ b/src/components/Input/Input.svelte
@@ -33,6 +33,7 @@
         bind:this="{input}"
         on:invalid="{handleInvalid}"
         on:input="{(e) => e.target.setCustomValidity('')}"
+        on:paste
         bind:value="{value}"
         {...$$restProps}
       />
@@ -44,6 +45,7 @@
         bind:this="{input}"
         on:invalid="{handleInvalid}"
         on:input="{(e) => e.target.setCustomValidity('')}"
+        on:paste
         bind:value="{value}"
         {...$$restProps}
       />
@@ -55,6 +57,7 @@
         bind:this="{input}"
         on:invalid="{handleInvalid}"
         on:input="{(e) => e.target.setCustomValidity('')}"
+        on:paste
         bind:value="{value}"
         {...$$restProps}
       />
@@ -66,6 +69,7 @@
         bind:this="{input}"
         on:invalid="{handleInvalid}"
         on:input="{(e) => e.target.setCustomValidity('')}"
+        on:paste
         bind:value="{value}"
         {...$$restProps}
       />

--- a/src/components/InputMultiple/InputMultiple.svelte
+++ b/src/components/InputMultiple/InputMultiple.svelte
@@ -11,6 +11,20 @@
     }
   }
 
+  function handlePaste(index, e) {
+    // Prevent the original value from actually being pasted
+    e.preventDefault();
+
+    const pastedValues = e.clipboardData.getData("text").split('\n').map(url => url.trim()).filter(Boolean)
+    const clonedValues = [...values];
+    if (clonedValues[index]) {
+      clonedValues.splice(index + 1, 0, ...pastedValues);
+    } else {
+      clonedValues.splice(index, 1, ...pastedValues);
+    }
+    values = clonedValues;
+  }
+
   function getAddons(index) {
     const addons = [
       {
@@ -56,6 +70,7 @@
       type="{type}"
       bind:value="{value}"
       addons="{getAddons(index)}"
+      on:paste="{(e) => handlePaste(index, e)}"
       {...$$restProps}
     />
   {/each}


### PR DESCRIPTION
After this PR any multiple input instance should accept pasting with multiple lines, in case this occurs the values will be split by newline, trimmed and filtered for empty values before being put into the inputs. In case you paste on top of field that already has a value the value will be perserved.

Resolves: https://github.com/johman10/flood-for-transmission/issues/537