### PR TITLE
Fix file priority

### DIFF
--- a/src/components/Modal/TorrentDetail/Files/Files.svelte
+++ b/src/components/Modal/TorrentDetail/Files/Files.svelte
@@ -27,12 +27,12 @@
   $: structure = getFolderStructure(files);
 
   const handleSelectedFilePrioChange = (event) => {
-    torrentDetails.setPriority($torrentDetails, selectedFiles, event.detail);
+    const fileIndices = selectedFiles.map((fileName) => files.findIndex(file => file.name === fileName))
+    torrentDetails.setPriority($torrentDetails, fileIndices, event.detail);
   };
 
   const handleSingleFilePrioChange = (fileIndex, event) => {
-    const fileName = files[fileIndex].name;
-    torrentDetails.setPriority($torrentDetails, [fileName], event.detail);
+    torrentDetails.setPriority($torrentDetails, [fileIndex], event.detail);
   };
 </script>
 

--- a/src/helpers/stores/torrentDetails.js
+++ b/src/helpers/stores/torrentDetails.js
@@ -52,13 +52,7 @@ function createTorrentDetailsStore() {
     subscribe,
     setTorrentId: torrentId.set,
     clearTorrentId: () => torrentId.set(0),
-    setPriority: (torrent, fileNames, priority) => {
-      const allFileNames = torrent[TRANSMISSION_COLUMN.FILES].map(
-        (file) => file.name
-      );
-      const fileIndices = fileNames.map((fileName) =>
-        allFileNames.indexOf(fileName)
-      );
+    setPriority: (torrent, fileIndices, priority) => {
       let params;
       switch (priority) {
         case -2:


### PR DESCRIPTION
Moves indices computation out of torrent details into files to properly support file sorting added in #544 

Closes #555 