### PR TITLE
Better regex for search and allow searching non ASCII chars

### DIFF
--- a/src/helpers/filterHelper.js
+++ b/src/helpers/filterHelper.js
@@ -61,7 +61,7 @@ export function statusFilter(status, torrent) {
 export function searchFilter(query, torrent) {
   if (!query) return true;
 
-  const replaceRegex = /[^a-z0-9]/g;
+  const replaceRegex = /[ \[\]\.·_-]/g;
   const searchValue = query.toLowerCase().replace(replaceRegex, '');
   const value = torrent[TRANSMISSION_COLUMN_NAME].toLowerCase().replace(
     replaceRegex,


### PR DESCRIPTION
for #129 

Some test cases:

```
> regex = /[ \[\]\.·_-]/g

> str1='[这是一部中文电影.Movie.With.Chinese.Title.2024.1080p.WEB-DL.HEVC.10bit.DTS5.1.2Audios-Release]'
'[这是一部中文电影.Movie.With.Chinese.Title.2024.1080p.WEB-DL.HEVC.10bit.DTS5.1.2Audios-Release]'
> str2='English.Movie.2024.1080p.WEB-DL.HEVC.10bit.DTS5.1.2Audios-Release]'
'English.Movie.2024.1080p.WEB-DL.HEVC.10bit.DTS5.1.2Audios-Release]'

> search1 = '中文'
'中文'
> search2 = 'English Movie'
'English Movie'

> str1.toLowerCase().replace(regex, '')
'这是一部中文电影moviewithchinesetitle20241080pwebdlhevc10bitdts512audiosrelease'
> str2.toLowerCase().replace(regex, '')
'englishmovie20241080pwebdlhevc10bitdts512audiosrelease'
> search1.toLowerCase().replace(regex, ' ')
'中文'
> search2.toLowerCase().replace(regex, ' ')
'english movie'
> search1.toLowerCase().replace(regex, '')
'中文'
> search2.toLowerCase().replace(regex, '')
'englishmovie'
> str1.toLowerCase().replace(regex, '').includes(search1.toLowerCase().replace(regex,''))
true
> str2.toLowerCase().replace(regex, '').includes(search2.toLowerCase().replace(regex,''))
true
```

Also tested locally in my transmission docker that points to the dev version of UI and it's working.

Cannot figure out how to get CORS working to just use `npm start` :/ 