### PR TITLE
Fix file selector in torrent details

### DIFF
--- a/src/components/Modal/TorrentDetail/Files/Files.svelte
+++ b/src/components/Modal/TorrentDetail/Files/Files.svelte
@@ -21,9 +21,7 @@
     { label: 'High', value: 1 },
   ];
 
-  $: files = $torrentDetails[TRANSMISSION_COLUMN_FILES].toSorted((a, b) =>
-    a.name.localeCompare(b.name)
-  );
+  $: files = $torrentDetails[TRANSMISSION_COLUMN_FILES];
   $: structure = getFolderStructure(files);
 
   const handleSelectedFilePrioChange = (event) => {

--- a/src/helpers/folderStructureHelper.js
+++ b/src/helpers/folderStructureHelper.js
@@ -36,6 +36,11 @@ export const getMainFolder = (downloadDir, sampleFile) => {
   return downloadDir;
 };
 
+const sortFolderStructure = (structure) => {
+  structure.files.sort((a, b) => a.name.localeCompare(b.name));
+  Object.keys(structure.folders).forEach(folder => sortFolderStructure(structure.folders[folder]))
+}
+
 export const getFolderStructure = (files) => {
   const structure = getEmptyFolder();
 
@@ -59,5 +64,8 @@ export const getFolderStructure = (files) => {
     });
     prevFolder.files.push(getFile(file, fileName, index));
   });
+
+  sortFolderStructure(structure);
+
   return structure;
 };


### PR DESCRIPTION
This PR aims to fix the issue described in https://github.com/johman10/flood-for-transmission/issues/575.

Sorting the file list before creating the folder structure could cause the file indices to be incorrect, leading to problems such as not downloading the correct file or folder.

I tested it with a torrent where I encountered this problem and it seems to work properly with this patch.