### PR TITLE
Add "Select All" button to top bar

### DIFF
--- a/src/components/Icon/CheckAllIcon.svelte
+++ b/src/components/Icon/CheckAllIcon.svelte
@@ -1,0 +1,12 @@
+<script>
+  export let viewBox;
+</script>
+
+<svg on:click class="icon" viewBox={viewBox}>
+  <path
+    d="M3 14.5A1.5 1.5 0 0 1 1.5 13V3A1.5 1.5 0 0 1 3 1.5h8a.5.5 0 0 1 0 1H3a.5.5 0 0 0-.5.5v10a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V8a.5.5 0 0 1 1 0v5a1.5 1.5 0 0 1-1.5 1.5H3z"
+  ></path>
+  <path
+    d="m8.354 10.354 7-7a.5.5 0 0 0-.708-.708L8 9.293 5.354 6.646a.5.5 0 1 0-.708.708l3 3a.5.5 0 0 0 .708 0z"
+  ></path>
+</svg>

--- a/src/components/Icon/Icon.svelte
+++ b/src/components/Icon/Icon.svelte
@@ -2,6 +2,7 @@
   import Active from './Active.svelte';
   import Add from './Add.svelte';
   import All from './All.svelte';
+  import CheckAllIcon from './CheckAllIcon.svelte';
   import CheckboxCheckmark from './CheckboxCheckmark.svelte';
   import Checkmark from './Checkmark.svelte';
   import Chevron from './Chevron.svelte';
@@ -36,6 +37,7 @@
     Active,
     Add,
     All,
+    CheckAllIcon,
     CheckboxCheckmark,
     Checkmark,
     Chevron,

--- a/src/components/TopBar/TopBar.svelte
+++ b/src/components/TopBar/TopBar.svelte
@@ -23,6 +23,10 @@
     panel.toggle();
   };
 
+  const handleSelectAll = () => {
+    selectedTorrents.set($torrents.map((t) => t.id));
+  };
+
   const handleStart = () => {
     torrents.start($selectedTorrents);
   };
@@ -45,6 +49,9 @@
     <div class="group">
       <button class="button" on:click={togglePanel}>
         <Icon name="MenuIcon" viewBox="0 0 60 60" />
+      </button>
+      <button class="button" on:click={handleSelectAll}>
+        <Icon name="CheckAllIcon" viewBox="0 0 16 16" />
       </button>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a simple "Select All" button to the top bar, which has the same behaviour as pressing `CTRL+A`. 

This is something that I find really useful to have when managing the torrents on mobile.

<img width="1278" height="300" alt="2025-09-06_22-41" src="https://github.com/user-attachments/assets/3b2192d4-70a1-40bb-b5b2-5373072e4936" />
<img width="1282" height="304" alt="2025-09-06_22-41_1" src="https://github.com/user-attachments/assets/44d57f29-ad0b-4ef4-832e-7dc464523227" />
