### PR TITLE
Only default to show panel on non-mobile screens

### DIFF
--- a/src/helpers/stores/panel.js
+++ b/src/helpers/stores/panel.js
@@ -5,7 +5,7 @@ const PANEL_SHOWN_STORAGE_KEY = 'panel-shown';
 function createPanelStore() {
   const value = window.localStorage.getItem(PANEL_SHOWN_STORAGE_KEY);
   const { subscribe, update, set } = writable(
-    value === 'true' || value === null
+    value === 'true' || (value === null && window.outerWidth > 550)
   );
 
   return {


### PR DESCRIPTION
Something really simple that also improved my personal mobile experience: on small screens, don't start with an open panel