### PR TITLE
Remove breaking `value` key from InputMultiple component

### DIFF
--- a/src/components/InputMultiple/InputMultiple.svelte
+++ b/src/components/InputMultiple/InputMultiple.svelte
@@ -68,7 +68,7 @@
       {label}
     </label>
   {/if}
-  {#each values as value, index (value)}
+  {#each values as value, index}
     <Input
       id="input-multiple-{index}"
       type={type}


### PR DESCRIPTION
Running into some issues with the latest release (19th July) on both [Docker](https://github.com/haugene/docker-transmission-openvpn) and Windows.

Reverting to 16th Nov release resolves these issues.

---

If you try to manually enter a URL, the text field is deselected after typing/deleting every character.

If you open the `Add Torrents` menu and try to open a new blank slot, you now get a `+` and `-` button for the top slot, and no second slot (as if the top slot has been removed):

<img width="494" height="307" alt="Image" src="https://github.com/user-attachments/assets/76791102-f4a2-4752-9c5b-3ab4e7896e49" />

I can also get it to completely lock up:

1. open the `Add Torrents` menu
2. click `+` on the top slot
3. click the now moved `+` on the top slot again
4. type a single character in the top slot (this will be duplicated in the second slot)
5. click `+` on the second slot
6. you can now no longer exit the menu (you have to refresh, but don't do that yet)
7. this causes console error: `Uncaught TypeError: Cannot read properties of undefined (reading 'prev')`
8. if you edit the text in either of the slots, you can now do so freely, rather than one character at a time
9. this causes console error: `Uncaught TypeError: Cannot read properties of undefined (reading 'props')`

---

After playing about with NPM, and a lot of trial and error, this seems to be the cause.

Again, this is very much a case of finding a solution through trial and error. Whether it's the 'right solution' that doesn't cause other issues I've not seen, I'll leave in your capable hands.