### PR TITLE
Prevent tagging when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
         uses: 'marvinpinto/action-automatic-releases@latest'
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          automatic_release_tag: '${{ env.tag_name }}'
           prerelease: false
           title: '${{ env.tag_name }}'
           files: |


### PR DESCRIPTION
A small fix to prevent tagging an already existing release.