### PR TITLE
Prevent UI from hanging in some specific cases

### DIFF
--- a/src/components/Modal/TorrentDetail/Peers/Peers.svelte
+++ b/src/components/Modal/TorrentDetail/Peers/Peers.svelte
@@ -46,14 +46,14 @@
       {#each peers as peer (peer.address)}
         <tr>
           <td class="address-cell">
-            {#if $ipAddress[peer.address]}
+            {#if $ipAddress[peer.address]?.country_code}
               <img
                 class="flag"
                 src="images/flags/{$ipAddress[
                   peer.address
                 ].country_code.toLowerCase()}.png"
-                alt={$ipAddress[peer.address].country_code}
-                title={$ipAddress[peer.address].country_name}
+                alt="{$ipAddress[peer.address].country_code}"
+                title="{$ipAddress[peer.address].country_name}"
               />
             {:else}
               <img class="flag" src="images/flags/_unknown.png" alt="Unknown" />


### PR DESCRIPTION
This PR resolves: #613 and #603

In the case of #603 I found that local addresses don't have a country code, which means requesting a file that doesn't exist, which means an exception and a hanging UI.

In the case of #613 I learned that my delay and duration logic didn't work anymore, most likely due to changes in the rendering order between Svelte 4 and 5, causing calculations to be made on the new value instead of the old. To resolve this I reassessed the logic and implemented a fix that should correctly calculate delay and duration.